### PR TITLE
Add tags for cluster, location, commit to e2e-test builds (#3074)

### DIFF
--- a/build/Makefile
+++ b/build/Makefile
@@ -171,7 +171,7 @@ GO_E2E_TEST_ARGS=--kubeconfig /root/.kube/$(kubeconfig_file)
 gotestsum_json=/tmp/agones.gotestsum.json
 ifdef GOTESTSUM_VERBOSE
 gotestsum_format=--format=testname \
-  --post-run-command="sh -c 'echo; echo --- RAW VERBOSE OUTPUT ---; jq -j \"select(.Output != null) | .Output\" < $(gotestsum_json); echo --- END RAW VERBOSE OUTPUT ---'"
+  --post-run-command="sh -c 'echo; echo --- RAW VERBOSE OUTPUT ---; jq -j \"select(.Output != null) | (\\\"VERBOSE: \\\" + .Output)\" < $(gotestsum_json); echo --- END RAW VERBOSE OUTPUT ---'"
 else
 gotestsum_format=--format=standard-quiet
 endif

--- a/ci/e2e-test-cloudbuild.yaml
+++ b/ci/e2e-test-cloudbuild.yaml
@@ -55,11 +55,16 @@ steps:
     - "${_TEST_CLUSTER_NAME}"
     - "${_TEST_CLUSTER_LOCATION}"
     - "${_REGISTRY}"
+    - "${_PARENT_COMMIT_SHA}"
   id: e2e-stable
   waitFor:
     - e2e-feature-gates
 
-tags: ['e2e-test']
+tags:
+  - "e2e-test"
+  - "cluster-${_TEST_CLUSTER_NAME}"
+  - "location-${_TEST_CLUSTER_LOCATION}"
+  - "commit-${_PARENT_COMMIT_SHA}"
 timeout: 5400s # 1.5h
 queueTtl: 7200s # 2h // only one set of e2es should be running at once
 

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -325,7 +325,7 @@ steps:
             testCluster="gke-autopilot-e2e-test-cluster-${version//./-}"
           fi
           { gcloud builds submit . --config=./ci/e2e-test-cloudbuild.yaml \
-            --substitutions _FEATURE_WITH_GATE=$featureWithGate,_FEATURE_WITHOUT_GATE=$featureWithoutGate,_CLOUD_PRODUCT=$cloudProduct,_TEST_CLUSTER_NAME=$testCluster,_TEST_CLUSTER_LOCATION=$testClusterLocation,_REGISTRY=${_REGISTRY} \
+            --substitutions _FEATURE_WITH_GATE=$featureWithGate,_FEATURE_WITHOUT_GATE=$featureWithoutGate,_CLOUD_PRODUCT=$cloudProduct,_TEST_CLUSTER_NAME=$testCluster,_TEST_CLUSTER_LOCATION=$testClusterLocation,_REGISTRY=${_REGISTRY},_PARENT_COMMIT_SHA=${COMMIT_SHA} \
             |& sed "s/^/${cloudProduct}-${version}: /"; } &
           pids+=($!)
         done


### PR DESCRIPTION
* Add tags for cluster, location, commit to e2e-test builds

This will allow us to slice test failures more easily in Logs Explorer / BigQuery

* Delineate verbose output more easily in firehose

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/googleforgames/agones/blob/main/CONTRIBUTING.md and developer guide https://github.com/googleforgames/agones/blob/main/build/README.md
2. Please label this pull request according to what type of issue you are addressing.
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/googleforgames/agones/blob/main/build/README.md#testing-and-building
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, press enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind breaking
> /kind bug
> /kind cleanup
> /kind documentation
> /kind feature
> /kind hotfix

**What this PR does / Why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
Closes #

**Special notes for your reviewer**:


